### PR TITLE
Show git version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ composer.lock
 .env-local
 composer.lock
 config/bcLDAP.php
+public/gitrevision.txt

--- a/git-create-revisioninfo-hook.sh
+++ b/git-create-revisioninfo-hook.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+## Automatically generate a file with git branch and revision info
+##
+## Example:
+##   [master]v2.0.0-beta-191(a830382)
+## Install:
+##   cp git-create-revisioninfo-hook.sh .git/hooks/post-commit
+##   cp git-create-revisioninfo-hook.sh .git/hooks/post-checkout
+##   cp git-create-revisioninfo-hook.sh .git/hooks/post-merge
+##   chmod +x .git/hooks/post-*
+
+FILENAME='public/gitrevision.txt'
+
+exec 1>&2
+branch=`git rev-parse --abbrev-ref HEAD`
+shorthash=`git log --pretty=format:'%h' -n 1`
+revcount=`git log --oneline | wc -l`
+latesttag=`git describe --tags --abbrev=0`
+
+VERSION="[$branch]$latesttag-$revcount($shorthash)"
+echo $VERSION > $FILENAME

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -37,17 +37,24 @@
 
  	<footer class="container footer" id="footer">
         <hr class="hidden-print">
-        <span class="col-xs-12 col-sm-6 col-md-6 text-dark-grey" align="center">
+        <span class="col-xs-12 col-sm-4 col-md-4 text-dark-grey" style="text-align: left;">
             <small>Etwas funktioniert nicht? Schreibe <a href="mailto:maxim.drachinskiy@bc-studentenclub.de">Maxim</a> an.</small>
         </span>
-        <span class="col-xs-12 col-sm-6 col-md-6 text-dark-grey" align="center">
+        <span class="col-xs-12 col-sm-4 col-md-4 text-dark-grey" style="text-align: center;">
+            @if(File::exists("gitrevision.txt"))
+                <small>{{File::get("gitrevision.txt")}}</small>
+            @else
+                <small>&nbsp;</small>
+            @endif
+        </span>
+        <span class="col-xs-12 col-sm-4 col-md-4 text-dark-grey" style="text-align: right;">
             <small>Mehr Infos? Besuche die <a href="http://github.com/4D44H/lara-vedst">Projektseite auf GitHub</a>.</small>
         </span>
         <br class="visible-xs visible-sm">
         <br>
         <br>
 	</footer>
-		
+
     <script src="{{ asset('/js/jquery-2.1.3.min.js') }}"></script>
     <script src="{{ asset('/js/bootstrap.min.js') }}"></script>
     <script src="{{ asset('/js/isotope.pkgd.min.js') }}"></script>

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -37,17 +37,17 @@
 
  	<footer class="container footer" id="footer">
         <hr class="hidden-print">
-        <span class="col-xs-12 col-sm-4 col-md-4 text-dark-grey" style="text-align: left;">
-            <small>Etwas funktioniert nicht? Schreibe <a href="mailto:maxim.drachinskiy@bc-studentenclub.de">Maxim</a> an.</small>
-        </span>
         <span class="col-xs-12 col-sm-4 col-md-4 text-dark-grey" style="text-align: center;">
+            <small>Etwas funktioniert nicht? Schreibe <a href="mailto:maxim.drachinskiy@bc-studentenclub.de">Maxim</a> eine Mail.</small>
+        </span>
+        <span class="col-xs-6 col-sm-4 col-md-4 text-dark-grey" style="text-align: center;">
             @if(File::exists("gitrevision.txt"))
                 <small>{{File::get("gitrevision.txt")}}</small>
             @else
                 <small>&nbsp;</small>
             @endif
         </span>
-        <span class="col-xs-12 col-sm-4 col-md-4 text-dark-grey" style="text-align: right;">
+        <span class="col-xs-6 col-sm-4 col-md-4 text-dark-grey" style="text-align: center;">
             <small>Mehr Infos? Besuche die <a href="http://github.com/4D44H/lara-vedst">Projektseite auf GitHub</a>.</small>
         </span>
         <br class="visible-xs visible-sm">


### PR DESCRIPTION
This change provides a post-commit (as well as post-checkout and post-merge) hook in order to generate a git-revision info file. The content of that file will be shown in the footer of lara. `public/gitrevision.txt` is part of gitignore and will be left out by lara if not available. This will be helpful when working with different versions: locally, in production, in beta-testing, ...

The changes themselves will not have any immediate effects as the hooks have to be activated first.

![screenshot](https://cloud.githubusercontent.com/assets/2870104/15740723/716e45f0-28b6-11e6-909a-c80d64b91c64.png)

**Testing:**
```
cd /path-to/lara-vedst
sh git-create-revisioninfo-hook.sh
cat public/gitrevision.txt
```
The content of `gitrevision.txt` should look similar to: "[show-git-version]v2.0.0-beta-207(083a5ae)". @4D44H I don't know how the latest tag part will look like on your system as you are not using any. I anticipate it to be blank, so hopefully no problem there.

The info should be in the footer by now.

**Setup:**
```
cp git-create-revisioninfo-hook.sh .git/hooks/post-commit
cp git-create-revisioninfo-hook.sh .git/hooks/post-checkout
cp git-create-revisioninfo-hook.sh .git/hooks/post-merge
chmod +x .git/hooks/post-*
```

**Final test:**
```
... do some changes ...
git commit ...
```
The footer should be automatically updated.
